### PR TITLE
Make build command a bit more obvious

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -717,10 +717,10 @@ export SPRING_DATASOURCE_PASSWORD=postgres_password
 Then run:
 
 ```bash
-mvnw install
+./mvnw install
 ```
 
-to build the app, and then
+from the project root to build the app, and then
 
 ```bash
 bin/run-local


### PR DESCRIPTION
This tripped me up for a bit wondering why `mvn` was on my path, but there wasn't a `mvnw`